### PR TITLE
Change to a safer version matching operator

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -15,7 +15,7 @@ include { singularityPreflight } from "$projectDir/modules/singularity"
 
 // Safeguard Nextflow minimum version, in case user is not using the included executable
 nextflowMinVersion = '23.10' 
-if( !nextflow.version.matches("${nextflowMinVersion}+") ) {
+if( !nextflow.version.matches(">=${nextflowMinVersion}") ) {
     log.error("The pipeline requires Nextflow version ${nextflowMinVersion} or greater -- You are running version $nextflow.version") 
     System.exit(1)
 }


### PR DESCRIPTION
Postfixing `+` for Nextflow version matching is not working as assumed
https://github.com/nextflow-io/nextflow/issues/5016

Change to the safer option of prefixing `>=`